### PR TITLE
🐛 fix(workflow): correct job name in workflow file

### DIFF
--- a/.github/workflows/use-gettext-compendium.yml
+++ b/.github/workflows/use-gettext-compendium.yml
@@ -70,7 +70,7 @@ on:
           [Required] The passphrase of the GPG private key.
 
 jobs:
-  gettext-compend-po:
+  gettext-compendium:
     if: ${{ inputs.ENABLE == 'true' }}
     runs-on: ${{ inputs.RUNNER }}
     steps:


### PR DESCRIPTION
Updated job name from `gettext-compend-po` to `gettext-compendium`.