### PR TITLE
✨ feat(workflow): add FREE_SPACE input to workflows

### DIFF
--- a/.github/workflows/use-mdbook-build-docs.yml
+++ b/.github/workflows/use-mdbook-build-docs.yml
@@ -24,6 +24,12 @@ on:
         default: '${{ github.ref }}'
         description: >
           [Optional] The git reference to be checked out. Defaults to '\$\{\{ github.ref \}\}'
+      FREE_SPACE:
+        type: string
+        required: false
+        default: 'false'
+        description: >
+          [Optional] Whether to free disk space before building (e.g., 'true' or 'false'). Defaults to 'false'.
       CMAKE_VERSION:
         type: string
         required: false
@@ -109,6 +115,7 @@ jobs:
           echo "inputs.ENABLE = ${{ inputs.ENABLE }}"
           echo "inputs.RUNNER = ${{ inputs.RUNNER }}"
           echo "inputs.CHECKOUT = ${{ inputs.CHECKOUT }}"
+          echo "inputs.FREE_SPACE = ${{ inputs.FREE_SPACE }}"
           echo "inputs.CMAKE_VERSION = ${{ inputs.CMAKE_VERSION }}"
           echo "inputs.CONDA_VERSION = ${{ inputs.CONDA_VERSION }}"
           echo "inputs.VERSION = ${{ inputs.VERSION }}"
@@ -128,6 +135,18 @@ jobs:
           ref: ${{ inputs.CHECKOUT }}
           token: ${{ secrets.ACTOR_GITHUB_TOKEN }}
           submodules: true
+
+      - name: Free Disk Space
+        if: ${{ inputs.FREE_SPACE == 'true' }}
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Install CMake
         uses: localizethedocs/ci-common/.github/actions/install-cmake@main

--- a/.github/workflows/use-mdbook-update-pot.yml
+++ b/.github/workflows/use-mdbook-update-pot.yml
@@ -24,6 +24,12 @@ on:
         default: '${{ github.ref }}'
         description: >
           [Optional] The git reference to be checked out. Defaults to '\$\{\{ github.ref \}\}'
+      FREE_SPACE:
+        type: string
+        required: false
+        default: 'false'
+        description: >
+          [Optional] Whether to free disk space before building (e.g., 'true' or 'false'). Defaults to 'false'.
       CMAKE_VERSION:
         type: string
         required: false
@@ -99,6 +105,7 @@ jobs:
           echo "inputs.ENABLE = ${{ inputs.ENABLE }}"
           echo "inputs.RUNNER = ${{ inputs.RUNNER }}"
           echo "inputs.CHECKOUT = ${{ inputs.CHECKOUT }}"
+          echo "inputs.FREE_SPACE = ${{ inputs.FREE_SPACE }}"
           echo "inputs.CMAKE_VERSION = ${{ inputs.CMAKE_VERSION }}"
           echo "inputs.CONDA_VERSION = ${{ inputs.CONDA_VERSION }}"
           echo "inputs.VERSION = ${{ inputs.VERSION }}"
@@ -119,6 +126,18 @@ jobs:
           token: ${{ secrets.ACTOR_GITHUB_TOKEN }}
           submodules: true
           fetch-depth: 0
+
+      - name: Free Disk Space
+        if: ${{ inputs.FREE_SPACE == 'true' }}
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Import GPG key for Signing Commit
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/use-sphinx-build-docs.yml
+++ b/.github/workflows/use-sphinx-build-docs.yml
@@ -24,6 +24,12 @@ on:
         default: '${{ github.ref }}'
         description: >
           [Optional] The git reference to be checked out. Defaults to '\$\{\{ github.ref \}\}'
+      FREE_SPACE:
+        type: string
+        required: false
+        default: 'false'
+        description: >
+          [Optional] Whether to free disk space before building (e.g., 'true' or 'false'). Defaults to 'false'.
       CMAKE_VERSION:
         type: string
         required: false
@@ -109,6 +115,7 @@ jobs:
           echo "inputs.ENABLE = ${{ inputs.ENABLE }}"
           echo "inputs.RUNNER = ${{ inputs.RUNNER }}"
           echo "inputs.CHECKOUT = ${{ inputs.CHECKOUT }}"
+          echo "inputs.FREE_SPACE = ${{ inputs.FREE_SPACE }}"
           echo "inputs.CMAKE_VERSION = ${{ inputs.CMAKE_VERSION }}"
           echo "inputs.CONDA_VERSION = ${{ inputs.CONDA_VERSION }}"
           echo "inputs.VERSION = ${{ inputs.VERSION }}"
@@ -128,6 +135,18 @@ jobs:
           ref: ${{ inputs.CHECKOUT }}
           token: ${{ secrets.ACTOR_GITHUB_TOKEN }}
           submodules: true
+
+      - name: Free Disk Space
+        if: ${{ inputs.FREE_SPACE == 'true' }}
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Install CMake
         uses: localizethedocs/ci-common/.github/actions/install-cmake@main

--- a/.github/workflows/use-sphinx-update-pot.yml
+++ b/.github/workflows/use-sphinx-update-pot.yml
@@ -24,6 +24,12 @@ on:
         default: '${{ github.ref }}'
         description: >
           [Optional] The git reference to be checked out. Defaults to '\$\{\{ github.ref \}\}'
+      FREE_SPACE:
+        type: string
+        required: false
+        default: 'false'
+        description: >
+          [Optional] Whether to free disk space before building (e.g., 'true' or 'false'). Defaults to 'false'.
       CMAKE_VERSION:
         type: string
         required: false
@@ -99,6 +105,7 @@ jobs:
           echo "inputs.ENABLE = ${{ inputs.ENABLE }}"
           echo "inputs.RUNNER = ${{ inputs.RUNNER }}"
           echo "inputs.CHECKOUT = ${{ inputs.CHECKOUT }}"
+          echo "inputs.FREE_SPACE = ${{ inputs.FREE_SPACE }}"
           echo "inputs.CMAKE_VERSION = ${{ inputs.CMAKE_VERSION }}"
           echo "inputs.CONDA_VERSION = ${{ inputs.CONDA_VERSION }}"
           echo "inputs.VERSION = ${{ inputs.VERSION }}"
@@ -119,6 +126,18 @@ jobs:
           token: ${{ secrets.ACTOR_GITHUB_TOKEN }}
           submodules: true
           fetch-depth: 0
+
+      - name: Free Disk Space
+        if: ${{ inputs.FREE_SPACE == 'true' }}
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Import GPG key for Signing Commit
         uses: crazy-max/ghaction-import-gpg@v6


### PR DESCRIPTION
Adds a new optional input `FREE_SPACE` to the workflows for freeing disk space before building. This input accepts 'true' or 'false' and defaults to 'false'.

- Updates `use-mdbook-build-docs.yml`
- Updates `use-mdbook-update-pot.yml`
- Updates `use-sphinx-build-docs.yml`
- Updates `use-sphinx-update-pot.yml`