### PR TITLE
🐛 fix(workflow): disable docker-images cleanup in free-disk-space action

### DIFF
--- a/.github/workflows/use-mdbook-build-docs.yml
+++ b/.github/workflows/use-mdbook-build-docs.yml
@@ -145,7 +145,7 @@ jobs:
           dotnet: true
           haskell: true
           large-packages: true
-          docker-images: true
+          docker-images: false
           swap-storage: true
 
       - name: Install CMake

--- a/.github/workflows/use-mdbook-update-pot.yml
+++ b/.github/workflows/use-mdbook-update-pot.yml
@@ -136,7 +136,7 @@ jobs:
           dotnet: true
           haskell: true
           large-packages: true
-          docker-images: true
+          docker-images: false
           swap-storage: true
 
       - name: Import GPG key for Signing Commit

--- a/.github/workflows/use-sphinx-build-docs.yml
+++ b/.github/workflows/use-sphinx-build-docs.yml
@@ -145,7 +145,7 @@ jobs:
           dotnet: true
           haskell: true
           large-packages: true
-          docker-images: true
+          docker-images: false
           swap-storage: true
 
       - name: Install CMake

--- a/.github/workflows/use-sphinx-update-pot.yml
+++ b/.github/workflows/use-sphinx-update-pot.yml
@@ -136,7 +136,7 @@ jobs:
           dotnet: true
           haskell: true
           large-packages: true
-          docker-images: true
+          docker-images: false
           swap-storage: true
 
       - name: Import GPG key for Signing Commit


### PR DESCRIPTION
Set `docker-images: false` in jlumbroso/free-disk-space to prevent conflicts with Docker-dependent actions like ben-z/gh-action-mutex.

Updated workflows:
- use-mdbook-build-docs.yml
- use-mdbook-update-pot.yml
- use-sphinx-build-docs.yml
- use-sphinx-update-pot.yml